### PR TITLE
fix(Collaborators): correct GitHub URL reference in social links

### DIFF
--- a/frontend/landing/src/sections/Collaborators/index.tsx
+++ b/frontend/landing/src/sections/Collaborators/index.tsx
@@ -18,7 +18,7 @@ export function Collaborators({ ...props }) {
           name: userInfo.name ?? userInfo.login,
           avatar: userInfo.avatar_url,
           socials: [
-            { provider: 'github', url: userInfo.url },
+            { provider: 'github', url: userInfo.html_url },
             ...await getUserSocialAccounts(contributor.login!)
           ],
         }


### PR DESCRIPTION
This pull request includes a small but important change to the `Collaborators` component in `index.tsx`. The change updates the URL for GitHub profiles to use the `html_url` property instead of the `url` property, ensuring that the correct, user-friendly profile link is displayed.