### PR TITLE
Fix/logo-alignment

### DIFF
--- a/frontend/react/src/components/Header/style.ts
+++ b/frontend/react/src/components/Header/style.ts
@@ -1,15 +1,18 @@
 import styled from "styled-components";
 
 export const HeaderContainer = styled.header`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  align-items: center;
   width: 100%;
   padding: 0 20px;
   border-bottom: 1px solid ${(props) => props.theme.borderColor};
 
   a {
-    margin: 0 auto;
-    transform: translateX(24px);
+    grid-column: 2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 `;
 


### PR DESCRIPTION
The flex layout was causing alignment issues with the centered link. Switching to grid provides more precise control over the layout and ensures proper centering of elements.

before
![Screenshot 2025-06-20 at 16-28-40 Stark Oveflow](https://github.com/user-attachments/assets/6c8e0f4d-0dff-45d7-8e54-0da573c3a1f7)

after
![Screenshot 2025-06-20 at 16-29-09 Stark Oveflow](https://github.com/user-attachments/assets/49f65457-0f1b-4a65-a4e4-38534a1cb6ea)


closes #37 