### PR TITLE
Fix: Adds forum id to get_questions

### DIFF
--- a/smartcontract/tests/StarkOverflowTest.cairo
+++ b/smartcontract/tests/StarkOverflowTest.cairo
@@ -359,9 +359,11 @@ fn it_should_not_be_able_to_retrieve_answers_for_a_non_existent_question() {
 #[test]
 fn it_should_return_void_values_for_when_no_questions() {
   let (_, stark_token_address) = deploy_mock_stark_token();
-  let (starkoverflow_dispatcher, _) = deploy_starkoverflow_contract(stark_token_address);
+  let (starkoverflow_dispatcher, starkoverflow_contract_address) = deploy_starkoverflow_contract(stark_token_address);
   
-  let (questions, total, has_next) = starkoverflow_dispatcher.get_questions(10, 1);
+  let forum_id = create_forum(starkoverflow_dispatcher, starkoverflow_contract_address);
+
+  let (questions, total, has_next) = starkoverflow_dispatcher.get_questions(forum_id, 10, 1);
 
   assert_eq!(total, 0, "Total should be 0");
   assert_eq!(questions.len(), 0, "Array should be empty");
@@ -369,37 +371,48 @@ fn it_should_return_void_values_for_when_no_questions() {
 }
 
 #[test]
-fn it_should_return_paginated_questions() {
+fn it_should_return_paginated_questions_for_a_forum() {
   let (stark_token_dispatcher, stark_token_address) = deploy_mock_stark_token();
   let (starkoverflow_dispatcher, starkoverflow_contract_address) = deploy_starkoverflow_contract(stark_token_address);
 
-  let forum_id = create_forum(starkoverflow_dispatcher, starkoverflow_contract_address);
+  let forum_id_1 = create_forum(starkoverflow_dispatcher, starkoverflow_contract_address);
+  let forum_id_2 = create_forum(starkoverflow_dispatcher, starkoverflow_contract_address);
 
-  let mut total_questions: u32 = 0;
-  while total_questions < 5 {
-    ask_question(starkoverflow_dispatcher, stark_token_dispatcher, forum_id);
-    total_questions += 1;
+  let mut total_questions: u32 = 6;
+  while total_questions > 0 {
+    if total_questions == 3 {
+      ask_question(starkoverflow_dispatcher, stark_token_dispatcher, forum_id_2);
+    } else {
+      ask_question(starkoverflow_dispatcher, stark_token_dispatcher, forum_id_1);
+    }
+    total_questions -= 1;
   };
 
-  let (questions_page1, total, has_next) = starkoverflow_dispatcher.get_questions(2, 1);
+  let (questions_page1, total, has_next) = starkoverflow_dispatcher.get_questions(forum_id_1, 2, 1);
   assert_eq!(total, 5, "Page 1: Total should be 5");
   assert_eq!(questions_page1.len(), 2, "Page 1: Should have 2 questions");
   assert_eq!(has_next, true, "Page 1: Should have next page");
   assert_eq!(*questions_page1.at(0).id, 1, "Page 1: First ID should be 1");
   assert_eq!(*questions_page1.at(1).id, 2, "Page 1: Second ID should be 2");
 
-  let (questions_page2, _, has_next) = starkoverflow_dispatcher.get_questions(2, 2);
+  let (questions_page2, _, has_next) = starkoverflow_dispatcher.get_questions(forum_id_1, 2, 2);
   assert_eq!(questions_page2.len(), 2, "Page 2: Should have 2 questions");
   assert_eq!(has_next, true, "Page 2: Should have next page");
   assert_eq!(*questions_page2.at(0).id, 3, "Page 2: First ID should be 3");
-  assert_eq!(*questions_page2.at(1).id, 4, "Page 2: Second ID should be 4");
+  assert_eq!(*questions_page2.at(1).id, 5, "Page 2: Second ID should be 5");
 
-  let (questions_page3, _, has_next) = starkoverflow_dispatcher.get_questions(2, 3);
+  let (questions_page3, _, has_next) = starkoverflow_dispatcher.get_questions(forum_id_1, 2, 3);
   assert_eq!(questions_page3.len(), 1, "Page 3: Should have 1 question");
   assert_eq!(has_next, false, "Page 3: Should NOT have next page");
-  assert_eq!(*questions_page3.at(0).id, 5, "Page 3: First ID should be 5");
+  assert_eq!(*questions_page3.at(0).id, 6, "Page 3: First ID should be 6");
 
-  let (questions_page4, _, has_next) = starkoverflow_dispatcher.get_questions(2, 4);
+  let (questions_page4, _, has_next) = starkoverflow_dispatcher.get_questions(forum_id_1, 2, 4);
   assert_eq!(questions_page4.len(), 0, "Page 4: Should have 0 questions");
   assert_eq!(has_next, false, "Page 4: Should NOT have next page");
+
+  let (questions_page1, total, has_next) = starkoverflow_dispatcher.get_questions(forum_id_2, 2, 1);
+  assert_eq!(total, 1, "Page 1: Total should be 1");
+  assert_eq!(questions_page1.len(), 1, "Page 1: Should have 1 question");
+  assert_eq!(has_next, false, "Page 1: Should NOT have next page");
+  assert_eq!(*questions_page1.at(0).id, 4, "Page 1: First ID should be 4");
 }


### PR DESCRIPTION
This pull request introduces changes to the `StarkOverflow` smart contract and its tests to support forum-specific question pagination. The updates modify the `get_questions` function to filter questions by forum ID, adjust data types for pagination parameters, and enhance test coverage to validate these changes. Below are the key changes grouped by theme:

Updated method from:
```rs
fn get_questions(self: @T, page_size: u64, page: u64) -> (Array<QuestionResponse>, u256, bool); // (questions, total, has_next)
```
to:
```rs
fn get_questions(self: @T, forum_id: u256, page_size: u64, page: u64) -> (Array<QuestionResponse>, u64, bool); // (questions, total, has_next)
```

### Core Functionality Updates:
* Updated the `get_questions` function in the `IStarkOverflow` trait and its implementation to include a `forum_id` parameter, enabling forum-specific question retrieval. Pagination parameters (`page_size` and `page`) were also changed from `u256` to `u64` for efficiency. (`[[1]](diffhunk://#diff-59477b71425cedd0a43e370f37b36892af7cd2c08e5aa64cfe144ff87e9d8f34L18-R18)`, `[[2]](diffhunk://#diff-59477b71425cedd0a43e370f37b36892af7cd2c08e5aa64cfe144ff87e9d8f34L201-R227)`)
* Modified the logic in `get_questions` to calculate total questions and paginate based on the `forum_id`-specific question IDs instead of global question IDs. (`[smartcontract/src/StarkOverflow.cairoL201-R227](diffhunk://#diff-59477b71425cedd0a43e370f37b36892af7cd2c08e5aa64cfe144ff87e9d8f34L201-R227)`)
* Adjusted the `has_next_page` calculation and return values to align with the forum-specific context. (`[smartcontract/src/StarkOverflow.cairoL247-R250](diffhunk://#diff-59477b71425cedd0a43e370f37b36892af7cd2c08e5aa64cfe144ff87e9d8f34L247-R250)`)

### Test Updates:
* Enhanced the test `it_should_return_void_values_for_when_no_questions` to include a `forum_id` parameter when calling `get_questions`. (`[smartcontract/tests/StarkOverflowTest.cairoL362-R417](diffhunk://#diff-44a1f296254900ce2f5367134e76584818729335d20809166ab270251137f406L362-R417)`)
* Updated the test `it_should_return_paginated_questions` to validate forum-specific pagination by creating multiple forums and ensuring questions are paginated correctly within each forum. Renamed the test to `it_should_return_paginated_questions_for_a_forum` for clarity. (`[smartcontract/tests/StarkOverflowTest.cairoL362-R417](diffhunk://#diff-44a1f296254900ce2f5367134e76584818729335d20809166ab270251137f406L362-R417)`)