### PR TITLE
feat: :sparkles: improve InpuForm and TagInput

### DIFF
--- a/frontend/react/src/components/InputForm/InputForm.test.tsx
+++ b/frontend/react/src/components/InputForm/InputForm.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { InputForm } from './index'
+
+// Mock theme for styled-components
+const mockTheme = {
+  background: '#ffffff',
+  borderColor: '#e5e7eb',
+  text: '#000000',
+  textSecondary: '#6b7280'
+}
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      {component}
+    </ThemeProvider>
+  )
+}
+
+describe('InputForm', () => {
+  const defaultProps = {
+    id: 'test-input',
+    value: '',
+    label: 'Test Label',
+    error: null,
+    setValue: vi.fn(),
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Accessibility - Label Association', () => {
+    it('should render with accessible label association', () => {
+      renderWithTheme(<InputForm {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      const label = screen.getByText('Test Label')
+
+      expect(input).toHaveAttribute('id', 'test-input')
+      expect(label.closest('label')).toHaveAttribute('for', 'test-input')
+    })
+
+    it('should associate label with input using htmlFor and id', () => {
+      renderWithTheme(<InputForm {...defaultProps} />)
+
+      const input = screen.getByLabelText('Test Label')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('id', 'test-input')
+    })
+  })
+
+  describe('Error Display and State', () => {
+    it('should display error message when error prop is provided', () => {
+      const errorMessage = 'This field is required'
+      renderWithTheme(<InputForm {...defaultProps} error={errorMessage} />)
+
+      expect(screen.getByText(errorMessage)).toBeInTheDocument()
+    })
+
+    it('should not display error message when error prop is null', () => {
+      renderWithTheme(<InputForm {...defaultProps} error={null} />)
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('should apply error styling when error is present', () => {
+      const errorMessage = 'Error message'
+      renderWithTheme(<InputForm {...defaultProps} error={errorMessage} />)
+
+      const errorElement = screen.getByText(errorMessage)
+      expect(errorElement).toHaveStyle({ color: '#ef4444' })
+    })
+
+    it('should apply error state styling to container when error is present', () => {
+      const errorMessage = 'Error message'
+      renderWithTheme(<InputForm {...defaultProps} error={errorMessage} />)
+
+      // Check that the error message is displayed
+      expect(screen.getByText(errorMessage)).toBeInTheDocument()
+
+      // The InputForm component uses $hasError prop for styled-components styling
+      // We can verify the error state through the presence of the error message
+      const input = screen.getByRole('textbox')
+      expect(input).toBeInTheDocument()
+    })
+  })
+
+  describe('Basic Input Interaction', () => {
+    it('should render with correct placeholder', () => {
+      const placeholder = 'Enter your text'
+      renderWithTheme(<InputForm {...defaultProps} placeholder={placeholder} />)
+
+      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
+    })
+
+    it('should display current value', () => {
+      const value = 'Current value'
+      renderWithTheme(<InputForm {...defaultProps} value={value} />)
+
+      expect(screen.getByDisplayValue(value)).toBeInTheDocument()
+    })
+
+    it('should call setValue when input changes', async () => {
+      const user = userEvent.setup()
+      const setValue = vi.fn()
+
+      renderWithTheme(<InputForm {...defaultProps} setValue={setValue} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+
+      expect(setValue).toHaveBeenCalledWith('t')
+      expect(setValue).toHaveBeenCalledWith('e')
+      expect(setValue).toHaveBeenCalledWith('s')
+      expect(setValue).toHaveBeenCalledWith('t')
+    })
+
+    it('should handle disabled state', () => {
+      renderWithTheme(<InputForm {...defaultProps} disabled={true} />)
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeDisabled()
+    })
+  })
+
+  describe('Validation Triggers', () => {
+    it('should call validateForm on keyup', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(<InputForm {...defaultProps} validateForm={validateForm} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'a')
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+
+    it('should call validateForm on blur', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(<InputForm {...defaultProps} validateForm={validateForm} />)
+
+      const input = screen.getByRole('textbox')
+      await user.click(input)
+      await user.tab()
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+
+    it('should not call validateForm when prop is not provided', async () => {
+      const user = userEvent.setup()
+
+      renderWithTheme(<InputForm {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.tab()
+
+      // Should not throw error when validateForm is undefined
+      expect(input).toBeInTheDocument()
+    })
+  })
+
+  describe('Additional Props and Children', () => {
+    it('should render children (icons)', () => {
+      const TestIcon = () => <span data-testid="test-icon">🔍</span>
+
+      renderWithTheme(
+        <InputForm {...defaultProps}>
+          <TestIcon />
+        </InputForm>
+      )
+
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument()
+    })
+
+    it('should pass through additional input props', () => {
+      renderWithTheme(
+        <InputForm
+          {...defaultProps}
+          autoComplete="email"
+          maxLength={50}
+          data-testid="custom-input"
+        />
+      )
+
+      const input = screen.getByTestId('custom-input')
+      expect(input).toHaveAttribute('autoComplete', 'email')
+      expect(input).toHaveAttribute('maxLength', '50')
+    })
+
+    it('should render with tooltip text', () => {
+      const tooltipText = 'This is helpful information'
+      renderWithTheme(<InputForm {...defaultProps} tooltipText={tooltipText} />)
+
+      // The tooltip text should be passed to Label component
+      expect(screen.getByText('Test Label')).toBeInTheDocument()
+    })
+  })
+
+  describe('Keyboard and Mouse Events', () => {
+    it('should handle onChange event correctly', async () => {
+      const user = userEvent.setup()
+      const setValue = vi.fn()
+
+      renderWithTheme(<InputForm {...defaultProps} setValue={setValue} />)
+
+      const input = screen.getByRole('textbox')
+      await user.clear(input)
+      await user.type(input, 'hello world')
+
+      // Should be called for each character
+      expect(setValue).toHaveBeenCalledTimes(11)
+      expect(setValue).toHaveBeenLastCalledWith('d')
+    })
+
+    it('should handle focus and blur events', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(<InputForm {...defaultProps} validateForm={validateForm} />)
+
+      const input = screen.getByRole('textbox')
+
+      // Focus the input
+      await user.click(input)
+      expect(input).toHaveFocus()
+
+      // Blur the input
+      await user.tab()
+      expect(input).not.toHaveFocus()
+      expect(validateForm).toHaveBeenCalled()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty string value', () => {
+      renderWithTheme(<InputForm {...defaultProps} value="" />)
+
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveValue('')
+    })
+
+    it('should handle long error messages', () => {
+      const longError = 'This is a very long error message that should still be displayed correctly in the interface'
+      renderWithTheme(<InputForm {...defaultProps} error={longError} />)
+
+      expect(screen.getByText(longError)).toBeInTheDocument()
+    })
+
+    it('should handle special characters in value', () => {
+      const specialValue = '!@#$%^&*()_+-=[]{}|;:,.<>?'
+      renderWithTheme(<InputForm {...defaultProps} value={specialValue} />)
+
+      expect(screen.getByDisplayValue(specialValue)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/react/src/components/TagInput/TagInput.test.tsx
+++ b/frontend/react/src/components/TagInput/TagInput.test.tsx
@@ -1,0 +1,513 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { TagInput } from './index'
+
+// Mock theme for styled-components
+const mockTheme = {
+  background: '#ffffff',
+  borderColor: '#e5e7eb',
+  text: '#000000',
+  textSecondary: '#6b7280'
+}
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      {component}
+    </ThemeProvider>
+  )
+}
+
+describe('TagInput', () => {
+  const defaultProps = {
+    id: 'test-tags',
+    label: 'Tags',
+    tags: [],
+    setTags: vi.fn(),
+    onChange: vi.fn(),
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Accessibility - Label Association', () => {
+    it('should render with accessible label association', () => {
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      const label = screen.getByText('Tags')
+
+      expect(input).toHaveAttribute('id', 'test-tags')
+      expect(label.closest('label')).toHaveAttribute('for', 'test-tags')
+    })
+
+    it('should associate label with input using htmlFor and id', () => {
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByLabelText('Tags')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('id', 'test-tags')
+    })
+
+    it('should have aria-describedby when error is present', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} error="Error message" />
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveAttribute('aria-describedby', 'test-tags-error')
+    })
+
+    it('should have role="alert" for error messages', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} error="Error message" />
+      )
+
+      const errorElement = screen.getByRole('alert')
+      expect(errorElement).toHaveTextContent('Error message')
+    })
+
+    it('should have aria-live="polite" for tag counter', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['tag1']} />)
+
+      const counter = screen.getByText('1/5 tags')
+      expect(counter).toHaveAttribute('aria-live', 'polite')
+    })
+
+    it('should have proper aria-label for remove buttons', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['react', 'javascript']} />)
+
+      const removeButtons = screen.getAllByLabelText(/Remove .+ tag/)
+      expect(removeButtons).toHaveLength(2)
+      expect(removeButtons[0]).toHaveAttribute('aria-label', 'Remove react tag')
+      expect(removeButtons[1]).toHaveAttribute('aria-label', 'Remove javascript tag')
+    })
+  })
+
+  describe('Error Display and State', () => {
+    it('should display error message when error prop is provided', () => {
+      const errorMessage = 'Please add at least one tag'
+      renderWithTheme(<TagInput {...defaultProps} error={errorMessage} />)
+
+      expect(screen.getByText(errorMessage)).toBeInTheDocument()
+    })
+
+    it('should not display error message when error prop is null', () => {
+      renderWithTheme(<TagInput {...defaultProps} error={null} />)
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('should apply error styling when error is present', () => {
+      const errorMessage = 'Error message'
+      renderWithTheme(<TagInput {...defaultProps} error={errorMessage} />)
+
+      const errorElement = screen.getByText(errorMessage)
+      expect(errorElement).toHaveStyle({ color: '#dc3545' })
+    })
+  })
+
+  describe('Adding Tags', () => {
+    it('should add tag when Enter key is pressed', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'react')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['react'])
+      expect(onChange).toHaveBeenCalledWith(['react'])
+    })
+
+    it('should add tag when Space key is pressed', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'javascript')
+
+      // Using fireEvent for more direct control
+      fireEvent.keyDown(input, { key: ' ' })
+
+      expect(setTags).toHaveBeenCalledWith(['javascript'])
+      expect(onChange).toHaveBeenCalledWith(['javascript'])
+    })
+
+    it('should add tag when typing space character', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'typescript ')
+
+      expect(setTags).toHaveBeenCalledWith(['typescript'])
+    })
+
+    it('should clear input after adding tag', async () => {
+      const user = userEvent.setup()
+
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'vue')
+      await user.keyboard('{Enter}')
+
+      expect(input).toHaveValue('')
+    })
+
+    it('should trim whitespace from tags', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '  angular  ')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['angular'])
+    })
+
+    it('should not add empty tags', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '   ')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).not.toHaveBeenCalled()
+    })
+
+    it('should not add duplicate tags', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} tags={['react']} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'react')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).not.toHaveBeenCalled()
+    })
+
+    it('should respect maxTags limit', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const maxTags = 2
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2']}
+          maxTags={maxTags}
+          setTags={setTags}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'tag3')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).not.toHaveBeenCalled()
+    })
+
+    it('should disable input when max tags reached', () => {
+      const maxTags = 2
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2']}
+          maxTags={maxTags}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeDisabled()
+      expect(input).toHaveAttribute('placeholder', 'Max 2 tags')
+    })
+
+    it('should call validateForm after adding tag', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} validateForm={validateForm} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+  })
+
+  describe('Removing Tags', () => {
+    it('should remove tag when remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react', 'vue']}
+          setTags={setTags}
+          onChange={onChange}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove react tag')
+      await user.click(removeButton)
+
+      expect(setTags).toHaveBeenCalledWith(['vue'])
+      expect(onChange).toHaveBeenCalledWith(['vue'])
+    })
+
+    it('should remove last tag when Backspace is pressed on empty input', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react', 'vue']}
+          setTags={setTags}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.click(input)
+      await user.keyboard('{Backspace}')
+
+      expect(setTags).toHaveBeenCalledWith(['react'])
+    })
+
+    it('should not remove tag when Backspace is pressed with text in input', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react']}
+          setTags={setTags}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Backspace}')
+
+      expect(setTags).not.toHaveBeenCalled()
+    })
+
+    it('should call validateForm after removing tag', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react']}
+          validateForm={validateForm}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove react tag')
+      await user.click(removeButton)
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+  })
+
+  describe('setTags and onChange Calls', () => {
+    it('should call both setTags and onChange with updated tag list when adding', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['existing']}
+          setTags={setTags}
+          onChange={onChange}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'newTag')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['existing', 'newTag'])
+      expect(onChange).toHaveBeenCalledWith(['existing', 'newTag'])
+    })
+
+    it('should call both setTags and onChange with updated tag list when removing', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2', 'tag3']}
+          setTags={setTags}
+          onChange={onChange}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove tag2 tag')
+      await user.click(removeButton)
+
+      expect(setTags).toHaveBeenCalledWith(['tag1', 'tag3'])
+      expect(onChange).toHaveBeenCalledWith(['tag1', 'tag3'])
+    })
+
+    it('should work with only setTags (no onChange)', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          setTags={setTags}
+        // No onChange prop
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['test'])
+    })
+  })
+
+  describe('Display and Visual Elements', () => {
+    it('should display existing tags as chips', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} tags={['react', 'javascript', 'typescript']} />
+      )
+
+      expect(screen.getByText('react')).toBeInTheDocument()
+      expect(screen.getByText('javascript')).toBeInTheDocument()
+      expect(screen.getByText('typescript')).toBeInTheDocument()
+    })
+
+    it('should show tag counter when tags exist', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['tag1', 'tag2']} />)
+
+      expect(screen.getByText('2/5 tags')).toBeInTheDocument()
+    })
+
+    it('should not show tag counter when no tags', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={[]} />)
+
+      expect(screen.queryByText(/\/5 tags/)).not.toBeInTheDocument()
+    })
+
+    it('should show custom maxTags in counter', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} tags={['tag1']} maxTags={3} />
+      )
+
+      expect(screen.getByText('1/3 tags')).toBeInTheDocument()
+    })
+
+    it('should render with custom placeholder', () => {
+      const placeholder = 'Add your tags here'
+      renderWithTheme(<TagInput {...defaultProps} placeholder={placeholder} />)
+
+      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
+    })
+
+    it('should render children (icons)', () => {
+      const TestIcon = () => <span data-testid="test-icon">🏷️</span>
+
+      renderWithTheme(
+        <TagInput {...defaultProps}>
+          <TestIcon />
+        </TagInput>
+      )
+
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases and Stress Testing', () => {
+    it('should handle very long tag names', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const longTag = 'a'.repeat(100)
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, longTag)
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith([longTag])
+    })
+
+    it('should handle special characters in tags', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const specialTag = 'tag@#$%^&*()'
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, specialTag)
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith([specialTag])
+    })
+
+    it('should handle empty tags array', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={[]} />)
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeInTheDocument()
+      expect(screen.queryByText(/Remove .+ tag/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Tooltip and Additional Props', () => {
+    it('should render with tooltip text', () => {
+      const tooltipText = 'Add relevant tags'
+      renderWithTheme(<TagInput {...defaultProps} tooltipText={tooltipText} />)
+
+      // The tooltip text should be passed to Label component
+      expect(screen.getByText('Tags')).toBeInTheDocument()
+    })
+
+    it('should handle no validateForm prop gracefully', async () => {
+      const user = userEvent.setup()
+
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      // Should not throw error when validateForm is undefined
+      expect(input).toHaveValue('')
+    })
+  })
+})

--- a/frontend/react/src/components/TagInput/index.tsx
+++ b/frontend/react/src/components/TagInput/index.tsx
@@ -11,6 +11,7 @@ interface TagInputProps {
   error?: string | null;
   tags: string[];
   setTags: (tags: string[]) => void;
+  onChange?: (tags: string[]) => void;
   validateForm?: () => void;
   maxTags?: number;
   children?: React.ReactElement;
@@ -20,10 +21,11 @@ export function TagInput({
   id,
   label,
   tooltipText,
-  placeholder = "Type a tag and press space",
+  placeholder = "Type a tag and press Enter or Space",
   error,
   tags,
   setTags,
+  onChange,
   validateForm,
   maxTags = 5,
   children
@@ -33,14 +35,18 @@ export function TagInput({
   const addTag = (tag: string) => {
     const trimmedTag = tag.trim();
     if (trimmedTag && !tags.includes(trimmedTag) && tags.length < maxTags) {
-      setTags([...tags, trimmedTag]);
+      const newTags = [...tags, trimmedTag];
+      setTags(newTags);
+      if (onChange) onChange(newTags);
       setInputValue("");
       if (validateForm) validateForm();
     }
   };
 
   const removeTag = (indexToRemove: number) => {
-    setTags(tags.filter((_, index) => index !== indexToRemove));
+    const newTags = tags.filter((_, index) => index !== indexToRemove);
+    setTags(newTags);
+    if (onChange) onChange(newTags);
     if (validateForm) validateForm();
   };
 
@@ -95,12 +101,24 @@ export function TagInput({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             disabled={tags.length >= maxTags}
+            aria-describedby={error ? `${id}-error` : undefined}
           />
         </TagsContainer>
       </TagInputContainer>
-      {error && <div style={{ color: "#dc3545", fontSize: "0.875rem", marginTop: "5px" }}>{error}</div>}
+      {error && (
+        <div
+          id={`${id}-error`}
+          role="alert"
+          style={{ color: "#dc3545", fontSize: "0.875rem", marginTop: "5px" }}
+        >
+          {error}
+        </div>
+      )}
       {tags.length > 0 && (
-        <div style={{ fontSize: "0.75rem", color: "#6c757d", marginTop: "5px" }}>
+        <div
+          style={{ fontSize: "0.75rem", color: "#6c757d", marginTop: "5px" }}
+          aria-live="polite"
+        >
           {tags.length}/{maxTags} tags
         </div>
       )}

--- a/frontend/react/src/components/TagInputNew/TagInput.test.tsx
+++ b/frontend/react/src/components/TagInputNew/TagInput.test.tsx
@@ -1,0 +1,598 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { TagInput } from '../TagInput/index'
+
+// Mock theme for styled-components
+const mockTheme = {
+  background: '#ffffff',
+  borderColor: '#e5e7eb',
+  text: '#000000',
+  textSecondary: '#6b7280'
+}
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      {component}
+    </ThemeProvider>
+  )
+}
+
+describe('TagInput', () => {
+  const defaultProps = {
+    id: 'test-tags',
+    label: 'Tags',
+    tags: [],
+    setTags: vi.fn(),
+    onChange: vi.fn(),
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Accessibility - Label Association', () => {
+    it('should render with accessible label association', () => {
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      const label = screen.getByText('Tags')
+
+      expect(input).toHaveAttribute('id', 'test-tags')
+      expect(label.closest('label')).toHaveAttribute('for', 'test-tags')
+    })
+
+    it('should associate label with input using htmlFor and id', () => {
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByLabelText('Tags')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('id', 'test-tags')
+    })
+
+    it('should have aria-describedby when error is present', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} error="Error message" />
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveAttribute('aria-describedby', 'test-tags-error')
+    })
+
+    it('should have role="alert" for error messages', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} error="Error message" />
+      )
+
+      const errorElement = screen.getByRole('alert')
+      expect(errorElement).toHaveTextContent('Error message')
+    })
+
+    it('should have aria-live="polite" for tag counter', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['tag1']} />)
+
+      const counter = screen.getByText('1/5 tags')
+      expect(counter).toHaveAttribute('aria-live', 'polite')
+    })
+
+    it('should have proper aria-label for remove buttons', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['react', 'javascript']} />)
+
+      const removeButtons = screen.getAllByLabelText(/Remove .+ tag/)
+      expect(removeButtons).toHaveLength(2)
+      expect(removeButtons[0]).toHaveAttribute('aria-label', 'Remove react tag')
+      expect(removeButtons[1]).toHaveAttribute('aria-label', 'Remove javascript tag')
+    })
+  })
+
+  describe('Error Display and State', () => {
+    it('should display error message when error prop is provided', () => {
+      const errorMessage = 'Please add at least one tag'
+      renderWithTheme(<TagInput {...defaultProps} error={errorMessage} />)
+
+      expect(screen.getByText(errorMessage)).toBeInTheDocument()
+    })
+
+    it('should not display error message when error prop is null', () => {
+      renderWithTheme(<TagInput {...defaultProps} error={null} />)
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('should apply error styling when error is present', () => {
+      const errorMessage = 'Error message'
+      renderWithTheme(<TagInput {...defaultProps} error={errorMessage} />)
+
+      const errorElement = screen.getByText(errorMessage)
+      expect(errorElement).toHaveStyle({ color: '#dc3545' })
+    })
+  })
+
+  describe('Adding Tags', () => {
+    it('should add tag when Enter key is pressed', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'react')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['react'])
+      expect(onChange).toHaveBeenCalledWith(['react'])
+    })
+
+    it('should add tag when Space key is pressed', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} setTags={setTags} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'javascript')
+
+      // Using fireEvent for more direct control
+      fireEvent.keyDown(input, { key: ' ' })
+
+      expect(setTags).toHaveBeenCalledWith(['javascript'])
+      expect(onChange).toHaveBeenCalledWith(['javascript'])
+    })
+
+    it('should add tag when typing space character', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'typescript ')
+
+      expect(onChange).toHaveBeenCalledWith(['typescript'])
+    })
+
+    it('should clear input after adding tag', async () => {
+      const user = userEvent.setup()
+
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'vue')
+      await user.keyboard('{Enter}')
+
+      expect(input).toHaveValue('')
+    })
+
+    it('should trim whitespace from tags', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '  angular  ')
+      await user.keyboard('{Enter}')
+
+      expect(onChange).toHaveBeenCalledWith(['angular'])
+    })
+
+    it('should not add empty tags', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '   ')
+      await user.keyboard('{Enter}')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('should not add duplicate tags', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} tags={['react']} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'react')
+      await user.keyboard('{Enter}')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('should respect maxTags limit', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const maxTags = 2
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2']}
+          maxTags={maxTags}
+          onChange={onChange}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'tag3')
+      await user.keyboard('{Enter}')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('should disable input when max tags reached', () => {
+      const maxTags = 2
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2']}
+          maxTags={maxTags}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeDisabled()
+      expect(input).toHaveAttribute('placeholder', 'Max 2 tags')
+    })
+
+    it('should call validateForm after adding tag', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} validateForm={validateForm} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+  })
+
+  describe('Removing Tags', () => {
+    it('should remove tag when remove button is clicked', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react', 'vue']}
+          onChange={onChange}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove react tag')
+      await user.click(removeButton)
+
+      expect(onChange).toHaveBeenCalledWith(['vue'])
+    })
+
+    it('should remove last tag when Backspace is pressed on empty input', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react', 'vue']}
+          onChange={onChange}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.click(input)
+      await user.keyboard('{Backspace}')
+
+      expect(onChange).toHaveBeenCalledWith(['react'])
+    })
+
+    it('should not remove tag when Backspace is pressed with text in input', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react']}
+          onChange={onChange}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Backspace}')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('should call validateForm after removing tag', async () => {
+      const user = userEvent.setup()
+      const validateForm = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['react']}
+          validateForm={validateForm}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove react tag')
+      await user.click(removeButton)
+
+      expect(validateForm).toHaveBeenCalled()
+    })
+  })
+
+  describe('setTags and onChange Calls', () => {
+    it('should call both setTags and onChange with updated tag list when adding', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['existing']}
+          setTags={setTags}
+          onChange={onChange}
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'newTag')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['existing', 'newTag'])
+      expect(onChange).toHaveBeenCalledWith(['existing', 'newTag'])
+    })
+
+    it('should call both setTags and onChange with updated tag list when removing', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          tags={['tag1', 'tag2', 'tag3']}
+          setTags={setTags}
+          onChange={onChange}
+        />
+      )
+
+      const removeButton = screen.getByLabelText('Remove tag2 tag')
+      await user.click(removeButton)
+
+      expect(setTags).toHaveBeenCalledWith(['tag1', 'tag3'])
+      expect(onChange).toHaveBeenCalledWith(['tag1', 'tag3'])
+    })
+
+    it('should work with only setTags (no onChange)', async () => {
+      const user = userEvent.setup()
+      const setTags = vi.fn()
+
+      renderWithTheme(
+        <TagInput
+          {...defaultProps}
+          setTags={setTags}
+        // No onChange prop
+        />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      expect(setTags).toHaveBeenCalledWith(['test'])
+    })
+  })
+
+  describe('Display and Visual Elements', () => {
+    it('should display existing tags as chips', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} tags={['react', 'javascript', 'typescript']} />
+      )
+
+      expect(screen.getByText('react')).toBeInTheDocument()
+      expect(screen.getByText('javascript')).toBeInTheDocument()
+      expect(screen.getByText('typescript')).toBeInTheDocument()
+    })
+
+    it('should show tag counter when tags exist', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={['tag1', 'tag2']} />)
+
+      expect(screen.getByText('2/5 tags')).toBeInTheDocument()
+    })
+
+    it('should not show tag counter when no tags', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={[]} />)
+
+      expect(screen.queryByText(/\/5 tags/)).not.toBeInTheDocument()
+    })
+
+    it('should show custom maxTags in counter', () => {
+      renderWithTheme(
+        <TagInput {...defaultProps} tags={['tag1']} maxTags={3} />
+      )
+
+      expect(screen.getByText('1/3 tags')).toBeInTheDocument()
+    })
+
+    it('should render with custom placeholder', () => {
+      const placeholder = 'Add your tags here'
+      renderWithTheme(<TagInput {...defaultProps} placeholder={placeholder} />)
+
+      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
+    })
+
+    it('should render children (icons)', () => {
+      const TestIcon = () => <span data-testid="test-icon">🏷️</span>
+
+      renderWithTheme(
+        <TagInput {...defaultProps}>
+          <TestIcon />
+        </TagInput>
+      )
+
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument()
+    })
+  })
+
+  describe('Keyboard Navigation and Events', () => {
+    it('should handle multiple rapid key presses', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+
+      // Add first tag
+      await user.type(input, 'a')
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      // Add second tag (component maintains internal state)
+      await user.type(input, 'b')
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      expect(onChange).toHaveBeenCalledTimes(2)
+      expect(onChange).toHaveBeenNthCalledWith(1, ['a'])
+      expect(onChange).toHaveBeenNthCalledWith(2, ['b'])
+    })
+
+    it('should prevent default behavior on Enter and Space', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+
+      // Test that Enter adds tag (implying preventDefault worked)
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(onChange).toHaveBeenCalledWith(['test'])
+
+      // Test that Space adds tag (implying preventDefault worked)
+      await user.type(input, 'test2')
+      fireEvent.keyDown(input, { key: ' ' })
+      expect(onChange).toHaveBeenCalledWith(['test2'])
+    })
+  })
+
+  describe('Edge Cases and Stress Testing', () => {
+    it('should handle very long tag names', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const longTag = 'a'.repeat(100)
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, longTag)
+      await user.keyboard('{Enter}')
+
+      expect(onChange).toHaveBeenCalledWith([longTag])
+    })
+
+    it('should handle special characters in tags', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const specialTag = 'tag@#$%^&*()'
+
+      renderWithTheme(<TagInput {...defaultProps} onChange={onChange} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, specialTag)
+      await user.keyboard('{Enter}')
+
+      expect(onChange).toHaveBeenCalledWith([specialTag])
+    })
+
+    it('should handle empty tags array', () => {
+      renderWithTheme(<TagInput {...defaultProps} tags={[]} />)
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeInTheDocument()
+      expect(screen.queryByText(/Remove .+ tag/)).not.toBeInTheDocument()
+    })
+
+    it('should handle rapid add/remove operations', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      renderWithTheme(
+        <TagInput {...defaultProps} tags={['existing']} onChange={onChange} />
+      )
+
+      const input = screen.getByRole('textbox')
+
+      // Add a tag
+      await user.type(input, 'new')
+      await user.keyboard('{Enter}')
+
+      // Immediately remove it
+      await user.keyboard('{Backspace}')
+
+      expect(onChange).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Tooltip and Additional Props', () => {
+    it('should render with tooltip text', () => {
+      const tooltipText = 'Add relevant tags'
+      renderWithTheme(<TagInput {...defaultProps} tooltipText={tooltipText} />)
+
+      // The tooltip text should be passed to Label component
+      expect(screen.getByText('Tags')).toBeInTheDocument()
+    })
+
+    it('should handle maxTags of 1', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      // Test with no tags initially
+      const { rerender } = renderWithTheme(
+        <TagInput {...defaultProps} maxTags={1} onChange={onChange} />
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'onlyTag')
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      expect(onChange).toHaveBeenCalledWith(['onlyTag'])
+
+      // Re-render with the tag added to test disabled state
+      rerender(
+        <ThemeProvider theme={mockTheme}>
+          <TagInput {...defaultProps} tags={['onlyTag']} maxTags={1} onChange={onChange} />
+        </ThemeProvider>
+      )
+
+      const updatedInput = screen.getByRole('textbox')
+      expect(updatedInput).toBeDisabled()
+    })
+
+    it('should handle no validateForm prop gracefully', async () => {
+      const user = userEvent.setup()
+
+      renderWithTheme(<TagInput {...defaultProps} />)
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'test')
+      await user.keyboard('{Enter}')
+
+      // Should not throw error when validateForm is undefined
+      expect(input).toHaveValue('')
+    })
+  })
+})


### PR DESCRIPTION
# ✨ Implement InputForm and TagInput Components


- [x] Closes #74    

---

### 📌 Type of Change

* [x] **InputForm**: label is accessible and linked to the input
* [x] **InputForm**: error text/state is rendered when provided
* [x] **TagInput**: add tag flow covered
* [x] **TagInput**: remove tag flow covered
* [x] **TagInput**: `onChange` receives the correct updated list
* [x] Stable selectors used; tests pass with `npm run test`
